### PR TITLE
Replaces method .success() which was deprecated in jQuery 1.8 with .d…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-jquery-ajax-goodies v0.3.1 [![Build Status](https://travis-ci.org/fantactuka/jquery-ajax-goodies.png?branch=master)](https://travis-ci.org/fantactuka/jquery-ajax-goodies)
+jquery-ajax-goodies v0.3.2 [![Build Status](https://travis-ci.org/fantactuka/jquery-ajax-goodies.png?branch=master)](https://travis-ci.org/fantactuka/jquery-ajax-goodies)
 ==================
 
 Adding `cached` (including ttl, optional local storage support) and `concurrency` (aborting or ignoring concurrent requests) options for better requests managing.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ jquery-ajax-goodies v0.3.2 [![Build Status](https://travis-ci.org/fantactuka/jqu
 Adding `cached` (including ttl, optional local storage support) and `concurrency` (aborting or ignoring concurrent requests) options for better requests managing.
 
 # Installation
-Using [Bower](http://twitter.github.com/bower/) `bower install jquery-ajax-goodies` or just copy [jquery-ajax-goodies.js](https://raw.github.com/fantactuka/jquery-ajax-goodies/master/jquery-ajax-goodies.js)
+Just copy [jquery-ajax-goodies.js](https://raw.githubusercontent.com/aavision/jquery-ajax-goodies/master/jquery-ajax-goodies.js)
 
 # Usage
 ## Concurrency 

--- a/bower.json
+++ b/bower.json
@@ -1,10 +1,10 @@
 {
-  "name": "jquery-ajax-goodies",
-  "version": "0.3.1",
-  "main": "jquery-ajax-goodies.js",
-  "ignore": [
-    "**/.*",
-    "node_modules",
-    "components"
-  ]
+    "name": "jquery-ajax-goodies",
+    "version": "0.3.2",
+    "main": "jquery-ajax-goodies.js",
+    "ignore": [
+        "**/.*",
+        "node_modules",
+        "components"
+    ]
 }

--- a/jquery-ajax-goodies-min.js
+++ b/jquery-ajax-goodies-min.js
@@ -1,1 +1,72 @@
-(function(e){"function"==typeof define&&define.amd?define(["jquery"],e):"object"==typeof exports?module.exports=e(require("jquery")):e(window.jQuery)})(function(e){function t(e,t){var r,n=e.data,s=e.stamp;switch(typeof t){case"boolean":r=t;break;case"function":r=!!t(n,s);break;case"object":r=+t>o();break;case"number":r=s>o()-t;break;default:throw"Invalid `cached` option value. Expected Number, Boolean, Function or Date, but got "+t}return r?n:null}function r(e,t){return{response:t,responseText:e.responseText,responseXML:e.responseXML,readyState:e.readyState,status:e.status,statusText:e.statusText,responseHeaders:e.getAllResponseHeaders()}}function n(t){var r,n=e.Deferred(),o={},a=t.responseHeaders,c=/^(.*?):[ \t]*([^\r\n]*)\r?$/gm;return s("setRequestHeader overrideMimeType statusCode abort",function(t){o[t]=e.noop}),s("responseText responseXML readyState status statusText",function(e){o[e]=t[e]}),o.getAllResponseHeaders=function(){return a},o.getResponseHeader=function(e){var t;if(!r)for(r={};t=c.exec(a);)r[t[1].toLowerCase()]=t[2];return t=r[e.toLowerCase()],t||null},n.resolve(t.response,t.statusText).promise(o),o.success=o.done,o.error=o.fail,o.complete=o.always,o}function o(){return+new Date}function s(t,r){e.each(t.split(" "),function(e,t){r(t)})}function a(e,t){throw t=t||{},e=e.replace(/\{([^{}]+)\}/g,function(e,r){return t[r]}),Error("$.ajax.goodies: "+e)}function c(e){return[e.type,e.url,e.data].join(":").toLowerCase()}function u(e,t){d.concurrents[e]=t,t.always(function(){delete d.concurrents[e]})}function i(e){var t=e.concurrency;return t&&{type:"string"==typeof t?t:t.type,key:t.key||c(e)}}var d=e.ajax.goodies={version:"0.3.1",concurrents:{}};d.cached={setAdapter:function(e){s("setItem getItem removeItem",function(t){e[t]||a('Method "{method}" is not implemented in adapter',{method:t})}),this._adapter=e},getAdapter:function(){return this._adapter||a("Adapter does not defined")}},d.cached.setAdapter({storage:{},setItem:function(e,t){this.storage[e]=t},getItem:function(e){return this.storage[e]},removeItem:function(e){delete this.storage[e]}}),e.ajaxPrefilter(function(s,a,u){if(s.cached){var i=c(s),f=d.cached.getAdapter(),p=f.getItem(i),l=p&&t(p,s.cached);if(l){u.abort();var m=n(l);e.extend(u,m),u.then(s.success,s.error).always(s.complete)}else p&&f.removeItem(i),u.success(function(e){f.setItem(i,{data:r(u,e),stamp:o()})})}}),e.ajaxPrefilter(function(e,t,r){var n,o,s=i(e);if(s)if(n=s.key,o=d.concurrents[n])switch(s.type){case"suppress":o.abort(),u(n,r);break;case"abort":r.abort();break;default:throw"Unsupported $.ajax.concurrents type: "+s.type}else u(n,r)})});
+! function(e) { "function" == typeof define && define.amd ? define(["jquery"], e) : "object" == typeof exports ? module.exports = e(require("jquery")) : e(window.jQuery) }(function(e) {
+    var t = e.ajax.goodies = { version: "0.3.2", concurrents: {} };
+
+    function r(e, t) { return { response: t, responseText: e.responseText, responseXML: e.responseXML, readyState: e.readyState, status: e.status, statusText: e.statusText, responseHeaders: e.getAllResponseHeaders() } }
+
+    function n() { return +new Date }
+
+    function o(t, r) { e.each(t.split(" "), function(e, t) { r(t) }) }
+
+    function s(e, t) { throw t = t || {}, e = e.replace(/\{([^{}]+)\}/g, function(e, r) { return t[r] }), new Error("$.ajax.goodies: " + e) }
+
+    function a(e) { return [e.type, e.url, e.data].join(":").toLowerCase() }
+
+    function c(e, r) { t.concurrents[e] = r, r.always(function() { delete t.concurrents[e] }) }
+    t.cached = { setAdapter: function(e) { o("setItem getItem removeItem", function(t) { e[t] || s('Method "{method}" is not implemented in adapter', { method: t }) }), this._adapter = e }, getAdapter: function() { return this._adapter || s("Adapter does not defined") } }, t.cached.setAdapter({ storage: {}, setItem: function(e, t) { this.storage[e] = t }, getItem: function(e) { return this.storage[e] }, removeItem: function(e) { delete this.storage[e] } }), e.ajaxPrefilter(function(s, c, u) {
+        if (s.cached) {
+            var i = a(s),
+                d = t.cached.getAdapter(),
+                f = d.getItem(i),
+                p = f && function(e, t) {
+                    var r, o = e.data,
+                        s = e.stamp;
+                    switch (typeof t) {
+                        case "boolean":
+                            r = t;
+                            break;
+                        case "function":
+                            r = !!t(o, s);
+                            break;
+                        case "object":
+                            r = n() < +t;
+                            break;
+                        case "number":
+                            r = s > n() - t;
+                            break;
+                        default:
+                            throw "Invalid `cached` option value. Expected Number, Boolean, Function or Date, but got " + t
+                    }
+                    return r ? o : null
+                }(f, s.cached);
+            if (p) {
+                u.abort();
+                var l = function(t) {
+                    var r, n = e.Deferred(),
+                        s = {},
+                        a = t.responseHeaders,
+                        c = /^(.*?):[ \t]*([^\r\n]*)\r?$/gm;
+                    return o("setRequestHeader overrideMimeType statusCode abort", function(t) { s[t] = e.noop }), o("responseText responseXML readyState status statusText", function(e) { s[e] = t[e] }), s.getAllResponseHeaders = function() { return a }, s.getResponseHeader = function(e) {
+                        var t;
+                        if (!r)
+                            for (r = {}; t = c.exec(a);) r[t[1].toLowerCase()] = t[2];
+                        return (t = r[e.toLowerCase()]) || null
+                    }, n.resolve(t.response, t.statusText).promise(s), s.success = s.done, s.error = s.fail, s.complete = s.always, s
+                }(p);
+                e.extend(u, l), u.then(s.success, s.error).always(s.complete)
+            } else f && d.removeItem(i), console.log(u), u.done(function(e) { d.setItem(i, { data: r(u, e), stamp: n() }) })
+        }
+    }), e.ajaxPrefilter(function(e, r, n) {
+        var o, s, u = function(e) { var t = e.concurrency; return t && { type: "string" == typeof t ? t : t.type, key: t.key || a(e) } }(e);
+        if (u)
+            if (o = u.key, s = t.concurrents[o]) switch (u.type) {
+                case "suppress":
+                    s.abort(), c(o, n);
+                    break;
+                case "abort":
+                    n.abort();
+                    break;
+                default:
+                    throw "Unsupported $.ajax.concurrents type: " + u.type
+            } else c(o, n)
+    })
+});

--- a/jquery-ajax-goodies.jquery.json
+++ b/jquery-ajax-goodies.jquery.json
@@ -8,19 +8,16 @@
         "concurrent",
         "cache"
     ],
-    "version": "0.3.1",
+    "version": "0.3.2",
     "author": {
         "name": "Maksim Horbachevsky",
         "url": "https://github.com/fantactuka"
     },
-    "maintainers": [
-    ],
-    "licenses": [
-        {
-            "type": "MIT",
-            "url": "https://github.com/fantactuka/jquery-ajax-goodies/LICENSE"
-        }
-    ],
+    "maintainers": [],
+    "licenses": [{
+        "type": "MIT",
+        "url": "https://github.com/fantactuka/jquery-ajax-goodies/LICENSE"
+    }],
     "bugs": "https://github.com/fantactuka/jquery-ajax-goodies/issues",
     "homepage": "https://github.com/fantactuka/jquery-ajax-goodies",
     "docs": "https://github.com/fantactuka/jquery-ajax-goodies",

--- a/jquery-ajax-goodies.js
+++ b/jquery-ajax-goodies.js
@@ -8,298 +8,298 @@
  */
 
 (function(factory) {
-  if (typeof define === 'function' && define.amd) {
-    define(['jquery'], factory);
-  } else if (typeof exports === 'object') {
-    module.exports = factory(require('jquery'));
-  } else {
-    factory(window.jQuery);
-  }
+    if (typeof define === 'function' && define.amd) {
+        define(['jquery'], factory);
+    } else if (typeof exports === 'object') {
+        module.exports = factory(require('jquery'));
+    } else {
+        factory(window.jQuery);
+    }
 })(function($) {
 
-  var goodies = $.ajax.goodies = {
-    version: '0.3.1',
-    concurrents: {}
-  };
+    var goodies = $.ajax.goodies = {
+        version: '0.3.2',
+        concurrents: {}
+    };
 
-  goodies.cached = {
-    setAdapter: function(adapter) {
-      each('setItem getItem removeItem', function(method) {
-        if (!adapter[method]) {
-          throwError('Method "{method}" is not implemented in adapter', { method: method });
+    goodies.cached = {
+        setAdapter: function(adapter) {
+            each('setItem getItem removeItem', function(method) {
+                if (!adapter[method]) {
+                    throwError('Method "{method}" is not implemented in adapter', { method: method });
+                }
+            });
+
+            this._adapter = adapter;
+        },
+
+        getAdapter: function() {
+            return this._adapter || throwError('Adapter does not defined');
         }
-      });
-
-      this._adapter = adapter;
-    },
-
-    getAdapter: function() {
-      return this._adapter || throwError('Adapter does not defined');
-    }
-  };
-
-  goodies.cached.setAdapter({
-    storage: {},
-
-    setItem: function(key, value) {
-      this.storage[key] = value;
-    },
-
-    getItem: function(key) {
-      return this.storage[key];
-    },
-
-    removeItem: function(key) {
-      delete this.storage[key];
-    }
-  });
-
-  function getRelevantData(cachedData, relevance) {
-    var data = cachedData.data,
-        stamp = cachedData.stamp,
-        valid;
-
-    switch (typeof relevance) {
-      case 'boolean':
-        valid = relevance;
-        break;
-      case 'function':
-        valid = !!relevance(data, stamp);
-        break;
-      case 'object':
-        valid = now() < +relevance;
-        break;
-      case 'number':
-        valid = stamp > now() - relevance;
-        break;
-      default:
-        throw 'Invalid `cached` option value. Expected Number, Boolean, Function or Date, but got ' + relevance;
-    }
-
-    return valid ? data : null;
-  }
-
-  function flattenXhr(jqXhr, response) {
-    return {
-      response: response,
-      responseText: jqXhr.responseText,
-      responseXML: jqXhr.responseXML,
-      readyState: jqXhr.readyState,
-      status: jqXhr.status,
-      statusText: jqXhr.statusText,
-      responseHeaders: jqXhr.getAllResponseHeaders()
-    };
-  }
-
-  function unflattenXhr(options) {
-    var deferred = $.Deferred(),
-        mockXhr = {},
-        headersObject,
-        headersString = options.responseHeaders,
-        headersRegExp = /^(.*?):[ \t]*([^\r\n]*)\r?$/mg;
-
-    // These helpers have no affect on request when it's done, so just noop-ing it
-    each('setRequestHeader overrideMimeType statusCode abort', function(helper) {
-      mockXhr[helper] = $.noop;
-    });
-
-    // Copy all plain properties
-    each('responseText responseXML readyState status statusText', function(property) {
-      mockXhr[property] = options[property];
-    });
-
-    // Mock all headers string getter
-    mockXhr.getAllResponseHeaders = function() {
-      return headersString;
     };
 
-    // Mock single header getter
-    mockXhr.getResponseHeader = function(key) {
-      var match;
+    goodies.cached.setAdapter({
+        storage: {},
 
-      if (!headersObject) {
-        headersObject = {};
-        while ((match = headersRegExp.exec(headersString))) {
-          headersObject[match[1].toLowerCase()] = match[2];
+        setItem: function(key, value) {
+            this.storage[key] = value;
+        },
+
+        getItem: function(key) {
+            return this.storage[key];
+        },
+
+        removeItem: function(key) {
+            delete this.storage[key];
         }
-      }
-
-      match = headersObject[key.toLowerCase()];
-      return match || null;
-    };
-
-    // Resolving deferred with cached response and status text
-    deferred.resolve(options.response, options.statusText).promise(mockXhr);
-
-    // Aliases for ajax promise
-    mockXhr.success = mockXhr.done;
-    mockXhr.error = mockXhr.fail;
-    mockXhr.complete = mockXhr.always;
-
-    return mockXhr;
-  }
-
-  function now() {
-    return +new Date();
-  }
-
-  function each(string, fn) {
-    $.each(string.split(' '), function(i, item) {
-      fn(item);
-    });
-  }
-
-  function throwError(message, values) {
-    values = values || {};
-    message = message.replace(/\{([^{}]+)\}/g, function(match, name) {
-      return values[name];
     });
 
-    throw new Error('$.ajax.goodies: ' + message);
-  }
+    function getRelevantData(cachedData, relevance) {
+        var data = cachedData.data,
+            stamp = cachedData.stamp,
+            valid;
 
-  /**
-   * Creating key for passed request settings, using type, url and data
-   * @param {Object} options
-   * @return {String}
-   */
-  function buildRequestKey(options) {
-    return [options.type, options.url, options.data].join(':').toLowerCase();
-  }
+        switch (typeof relevance) {
+            case 'boolean':
+                valid = relevance;
+                break;
+            case 'function':
+                valid = !!relevance(data, stamp);
+                break;
+            case 'object':
+                valid = now() < +relevance;
+                break;
+            case 'number':
+                valid = stamp > now() - relevance;
+                break;
+            default:
+                throw 'Invalid `cached` option value. Expected Number, Boolean, Function or Date, but got ' + relevance;
+        }
 
-  /**
-   * Ajax cache pre-filter. Adds `cached` option that allows permanent result caching if
-   * value is true.
-   *
-   *
-   *
-   * Example:
-   *    $.ajax({ url: 'test', cached: true });    // Will run actual request
-   *    $.ajax({ url: 'test', cached: true });    // Returns cached jqXhr, and does not run request
-   *
-   *
-   *
-   * How it works:
-   * It stores succeeded jqXhr object. When we have cached result, we abort
-   * new request and replace all properties/methods of current jqXhr with cached one. So
-   * when this merged jqXhr object is returned — it already a resolved deferred object,
-   * and adding any callbacks like .done, .fail, .always will be triggered immediately.
-   */
-  $.ajaxPrefilter(function(options, origOptions, jqXhr) {
-    if (!options.cached) {
-      return;
+        return valid ? data : null;
     }
 
-    var requestKey = buildRequestKey(options),
-        adapter = goodies.cached.getAdapter(),
-        cachedItem = adapter.getItem(requestKey),
-        relevantData = cachedItem && getRelevantData(cachedItem, options.cached);
+    function flattenXhr(jqXhr, response) {
+        return {
+            response: response,
+            responseText: jqXhr.responseText,
+            responseXML: jqXhr.responseXML,
+            readyState: jqXhr.readyState,
+            status: jqXhr.status,
+            statusText: jqXhr.statusText,
+            responseHeaders: jqXhr.getAllResponseHeaders()
+        };
+    }
 
-    if (relevantData) {
+    function unflattenXhr(options) {
+        var deferred = $.Deferred(),
+            mockXhr = {},
+            headersObject,
+            headersString = options.responseHeaders,
+            headersRegExp = /^(.*?):[ \t]*([^\r\n]*)\r?$/mg;
 
-      // Aborting current request
-      jqXhr.abort();
-
-      // Replacing current jqXhr with mocked
-      var xhr = unflattenXhr(relevantData);
-      $.extend(jqXhr, xhr);
-
-      // Adding callbacks that was passed as standard jqXhr options
-      jqXhr.then(options.success, options.error).always(options.complete);
-    } else {
-
-      // If any data was cached but no longer relevant
-      if (cachedItem) {
-        adapter.removeItem(requestKey);
-      }
-
-      // Caching response data
-      jqXhr.success(function(response) {
-        adapter.setItem(requestKey, {
-          data: flattenXhr(jqXhr, response),
-          stamp: now()
+        // These helpers have no affect on request when it's done, so just noop-ing it
+        each('setRequestHeader overrideMimeType statusCode abort', function(helper) {
+            mockXhr[helper] = $.noop;
         });
-      });
-    }
-  });
 
-  /**
-   * Stores concurrent request in local cache and delete it when request
-   * completed (whether with error or success)
-   * @param {String} key
-   * @param {XMLHttpRequest} jqXhr - jquery xhr deferred
-   */
-  function storeConcurrent(key, jqXhr) {
-    goodies.concurrents[key] = jqXhr;
-    jqXhr.always(function() {
-      delete goodies.concurrents[key];
+        // Copy all plain properties
+        each('responseText responseXML readyState status statusText', function(property) {
+            mockXhr[property] = options[property];
+        });
+
+        // Mock all headers string getter
+        mockXhr.getAllResponseHeaders = function() {
+            return headersString;
+        };
+
+        // Mock single header getter
+        mockXhr.getResponseHeader = function(key) {
+            var match;
+
+            if (!headersObject) {
+                headersObject = {};
+                while ((match = headersRegExp.exec(headersString))) {
+                    headersObject[match[1].toLowerCase()] = match[2];
+                }
+            }
+
+            match = headersObject[key.toLowerCase()];
+            return match || null;
+        };
+
+        // Resolving deferred with cached response and status text
+        deferred.resolve(options.response, options.statusText).promise(mockXhr);
+
+        // Aliases for ajax promise
+        mockXhr.success = mockXhr.done;
+        mockXhr.error = mockXhr.fail;
+        mockXhr.complete = mockXhr.always;
+
+        return mockXhr;
+    }
+
+    function now() {
+        return +new Date();
+    }
+
+    function each(string, fn) {
+        $.each(string.split(' '), function(i, item) {
+            fn(item);
+        });
+    }
+
+    function throwError(message, values) {
+        values = values || {};
+        message = message.replace(/\{([^{}]+)\}/g, function(match, name) {
+            return values[name];
+        });
+
+        throw new Error('$.ajax.goodies: ' + message);
+    }
+
+    /**
+     * Creating key for passed request settings, using type, url and data
+     * @param {Object} options
+     * @return {String}
+     */
+    function buildRequestKey(options) {
+        return [options.type, options.url, options.data].join(':').toLowerCase();
+    }
+
+    /**
+     * Ajax cache pre-filter. Adds `cached` option that allows permanent result caching if
+     * value is true.
+     *
+     *
+     *
+     * Example:
+     *    $.ajax({ url: 'test', cached: true });    // Will run actual request
+     *    $.ajax({ url: 'test', cached: true });    // Returns cached jqXhr, and does not run request
+     *
+     *
+     *
+     * How it works:
+     * It stores succeeded jqXhr object. When we have cached result, we abort
+     * new request and replace all properties/methods of current jqXhr with cached one. So
+     * when this merged jqXhr object is returned — it already a resolved deferred object,
+     * and adding any callbacks like .done, .fail, .always will be triggered immediately.
+     */
+    $.ajaxPrefilter(function(options, origOptions, jqXhr) {
+        if (!options.cached) {
+            return;
+        }
+
+        var requestKey = buildRequestKey(options),
+            adapter = goodies.cached.getAdapter(),
+            cachedItem = adapter.getItem(requestKey),
+            relevantData = cachedItem && getRelevantData(cachedItem, options.cached);
+
+        if (relevantData) {
+
+            // Aborting current request
+            jqXhr.abort();
+
+            // Replacing current jqXhr with mocked
+            var xhr = unflattenXhr(relevantData);
+            $.extend(jqXhr, xhr);
+
+            // Adding callbacks that was passed as standard jqXhr options
+            jqXhr.then(options.success, options.error).always(options.complete);
+        } else {
+
+            // If any data was cached but no longer relevant
+            if (cachedItem) {
+                adapter.removeItem(requestKey);
+            }
+
+            // Caching response data
+            jqXhr.done(function(response) {
+                adapter.setItem(requestKey, {
+                    data: flattenXhr(jqXhr, response),
+                    stamp: now()
+                });
+            });
+        }
     });
-  }
 
-  /**
-   * Parsing concurrency option into object with predefined key and type, or return
-   * null if concurrency is not configured
-   * @param {Object} options
-   * @return {Object|null}
-   */
-  function parseConcurrency(options) {
-    var concurrency = options.concurrency;
-
-    return concurrency && {
-      type: (typeof concurrency === 'string') ? concurrency : concurrency.type,
-      key: concurrency.key || buildRequestKey(options)
-    };
-  }
-
-  /**
-   * Ajax concurrency pre-filter. Adds `concurrency` option that allows to manage
-   * concurrent requests.
-   *
-   * Example:
-   *    $.ajax({ url: 'test', concurrency: 'suppress' });
-   *    $.ajax({ url: 'test', concurrency: 'suppress' }); // If previous request is not finished yet, will abort it
-   *
-   *    $.ajax({ url: 'test', concurrency: 'abort' });
-   *    $.ajax({ url: 'test', concurrency: 'abort' }); // If previous request is not finished yet, will abort new one
-   *
-   * Concurrent requests are stored by request key, that is built from method (get, post), url and data (get params),
-   * but it also possible to define own key for cases when request should manage concurrents, but might use
-   * different data. E.g. when requesting for search or suggestions.
-   *
-   *    $.ajax({ url: 'search', data: {q: 'a'}, concurrency: { key: 'search', type: 'suppress' } });
-   *    $.ajax({ url: 'search', data: {q: 'b'}, concurrency: { key: 'search', type: 'suppress' } });
-   *
-   * In example above requests would be concurrent event though they have a different set of data, since
-   * we specified concurrency key.
-   */
-  $.ajaxPrefilter(function(options, origOptions, jqXhr) {
-    var key,
-        concurrent,
-        concurrency = parseConcurrency(options);
-
-    if (!concurrency) {
-      return;
+    /**
+     * Stores concurrent request in local cache and delete it when request
+     * completed (whether with error or success)
+     * @param {String} key
+     * @param {XMLHttpRequest} jqXhr - jquery xhr deferred
+     */
+    function storeConcurrent(key, jqXhr) {
+        goodies.concurrents[key] = jqXhr;
+        jqXhr.always(function() {
+            delete goodies.concurrents[key];
+        });
     }
 
-    key = concurrency.key;
-    concurrent = goodies.concurrents[key];
+    /**
+     * Parsing concurrency option into object with predefined key and type, or return
+     * null if concurrency is not configured
+     * @param {Object} options
+     * @return {Object|null}
+     */
+    function parseConcurrency(options) {
+        var concurrency = options.concurrency;
 
-    if (concurrent) {
-      switch (concurrency.type) {
-        case 'suppress':
-          concurrent.abort();
-          storeConcurrent(key, jqXhr);
-          break;
-
-        case 'abort':
-          jqXhr.abort();
-          break;
-
-        default:
-          throw 'Unsupported $.ajax.concurrents type: ' + concurrency.type;
-      }
-    } else {
-      storeConcurrent(key, jqXhr);
+        return concurrency && {
+            type: (typeof concurrency === 'string') ? concurrency : concurrency.type,
+            key: concurrency.key || buildRequestKey(options)
+        };
     }
-  });
+
+    /**
+     * Ajax concurrency pre-filter. Adds `concurrency` option that allows to manage
+     * concurrent requests.
+     *
+     * Example:
+     *    $.ajax({ url: 'test', concurrency: 'suppress' });
+     *    $.ajax({ url: 'test', concurrency: 'suppress' }); // If previous request is not finished yet, will abort it
+     *
+     *    $.ajax({ url: 'test', concurrency: 'abort' });
+     *    $.ajax({ url: 'test', concurrency: 'abort' }); // If previous request is not finished yet, will abort new one
+     *
+     * Concurrent requests are stored by request key, that is built from method (get, post), url and data (get params),
+     * but it also possible to define own key for cases when request should manage concurrents, but might use
+     * different data. E.g. when requesting for search or suggestions.
+     *
+     *    $.ajax({ url: 'search', data: {q: 'a'}, concurrency: { key: 'search', type: 'suppress' } });
+     *    $.ajax({ url: 'search', data: {q: 'b'}, concurrency: { key: 'search', type: 'suppress' } });
+     *
+     * In example above requests would be concurrent event though they have a different set of data, since
+     * we specified concurrency key.
+     */
+    $.ajaxPrefilter(function(options, origOptions, jqXhr) {
+        var key,
+            concurrent,
+            concurrency = parseConcurrency(options);
+
+        if (!concurrency) {
+            return;
+        }
+
+        key = concurrency.key;
+        concurrent = goodies.concurrents[key];
+
+        if (concurrent) {
+            switch (concurrency.type) {
+                case 'suppress':
+                    concurrent.abort();
+                    storeConcurrent(key, jqXhr);
+                    break;
+
+                case 'abort':
+                    jqXhr.abort();
+                    break;
+
+                default:
+                    throw 'Unsupported $.ajax.concurrents type: ' + concurrency.type;
+            }
+        } else {
+            storeConcurrent(key, jqXhr);
+        }
+    });
 });

--- a/package.json
+++ b/package.json
@@ -1,16 +1,16 @@
 {
-  "name": "jquery-ajax-goodies",
-  "version": "0.3.1",
-  "scripts": {
-    "test": "grunt test"
-  },
-  "dependencies": {},
-  "devDependencies": {
-    "grunt": "0.4.0",
-    "grunt-karma": "0.4.4",
-    "grunt-contrib-jshint": "0.1.1",
-    "grunt-contrib-uglify": "0.1.1",
-    "grunt-contrib-qunit": "0.1.1",
-    "grunt-version": "0.2.1"
-  }
+    "name": "jquery-ajax-goodies",
+    "version": "0.3.2",
+    "scripts": {
+        "test": "grunt test"
+    },
+    "dependencies": {},
+    "devDependencies": {
+        "grunt": "0.4.0",
+        "grunt-karma": "0.4.4",
+        "grunt-contrib-jshint": "0.1.1",
+        "grunt-contrib-uglify": "0.1.1",
+        "grunt-contrib-qunit": "0.1.1",
+        "grunt-version": "0.2.1"
+    }
 }


### PR DESCRIPTION
jqXhr.done(function(response) {
                adapter.setItem(requestKey, {
                    data: flattenXhr(jqXhr, response),
                    stamp: now()
                });
});